### PR TITLE
工作目录使用可执行文件所在目录

### DIFF
--- a/NewLife.Agent/Systemd.cs
+++ b/NewLife.Agent/Systemd.cs
@@ -172,7 +172,7 @@ public class Systemd : DefaultHost
         sb.AppendLine("Type=simple");
         //sb.AppendLine($"ExecStart=/usr/bin/dotnet {asm.Location}");
         sb.AppendLine($"ExecStart={fileName} {arguments}");
-        sb.AppendLine($"WorkingDirectory={".".GetFullPath()}");
+        sb.AppendLine($"WorkingDirectory={Path.GetDirectoryName(fileName).GetFullPath()}");
         if (!user.IsNullOrEmpty()) sb.AppendLine($"User={user}");
         if (!group.IsNullOrEmpty()) sb.AppendLine($"Group={group}");
 


### PR DESCRIPTION
当在程序A中为B程序写配置文件时，使用A所在目录为工作目录可能会有问题